### PR TITLE
avoid CGImageRef leak

### DIFF
--- a/Sources/avifc/AVIFAnimatedDecoder.mm
+++ b/Sources/avifc/AVIFAnimatedDecoder.mm
@@ -70,6 +70,7 @@
 #else
     image = [UIImage imageWithCGImage:ref scale:1 orientation:UIImageOrientationUp];
 #endif
+    CGImageRelease(ref); // avoid leak
     return image;
 }
 


### PR DESCRIPTION
After using `[UIImage imageWithCGImage:ref]`, the original CGImageRef object ref can and should be released, provided that you own the CGImageRef (i.e., it was created through methods such as CGImageCreate or you have called CGImageRetain).